### PR TITLE
홈 레이아웃 구현

### DIFF
--- a/lib/common/widget/w_width_and_height.dart
+++ b/lib/common/widget/w_width_and_height.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class Height extends StatelessWidget {
+  final double height;
+
+  const Height(
+    this.height, {
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: height,
+    );
+  }
+}
+
+class Width extends StatelessWidget {
+  final double width;
+
+  const Width(
+    this.width, {
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: width,
+    );
+  }
+}

--- a/lib/common/widget/widget_constant.dart
+++ b/lib/common/widget/widget_constant.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/cupertino.dart';
+import 'package:word_english/common/widget/w_width_and_height.dart';
+
+const spacer = Spacer();
+
+const width10 = Width(10);
+const width20 = Width(20);
+const width30 = Width(30);
+
+const height10 = Height(10);
+const height20 = Height(20);
+const height30 = Height(30);

--- a/lib/screen/home/s_home.dart
+++ b/lib/screen/home/s_home.dart
@@ -1,11 +1,71 @@
 import 'package:flutter/material.dart';
 import 'package:velocity_x/velocity_x.dart';
+import 'package:word_english/common/widget/widget_constant.dart';
+import 'package:word_english/screen/home/widget/w_banner.dart';
+import 'package:word_english/screen/home/widget/w_chapter_item.dart';
+import 'package:word_english/util/local_json.dart';
 
-class HomeScreen extends StatelessWidget {
+import '../../model/chapter_item_model.dart';
+
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
   @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  List<ChapterItem> chapterList = [];
+
+  @override
+  void initState() {
+    super.initState();
+    initData();
+  }
+
+  void initData() async {
+    final list = await LocalJson.getObjectList<ChapterItem>("json/data.json");
+    setState(() {
+      chapterList = list;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Center(child: 'Home'.text.make(),);
+    return SafeArea(
+      child: Scaffold(
+        body: Stack(
+          children: [
+            SingleChildScrollView(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  BannerWidget(height: 100).p(8), // 배너 이미지
+                  height20,
+                  chapterList.isEmpty
+                      ? const Center(
+                          child: CircularProgressIndicator(),
+                        )
+                      : ListView.separated(
+                          separatorBuilder: (context, index) => const Divider(
+                            thickness: 1,
+                            color: Colors.transparent,
+                          ),
+                          itemBuilder: (context, index) {
+                            return ChapterItemWidget(
+                                chapterItem: chapterList[index]);
+                          },
+                          itemCount: chapterList.length,
+                          shrinkWrap: true,
+                          physics:
+                              const NeverScrollableScrollPhysics(), // SingleChildScrollView로 스크롤을 대신함
+                        ),
+                ],
+              ).pOnly(top: 20, bottom: 65, left: 20, right: 20),
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }

--- a/lib/screen/home/widget/w_banner.dart
+++ b/lib/screen/home/widget/w_banner.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class BannerWidget extends StatefulWidget {
+  final double height;
+  final String? imagePath;
+
+  BannerWidget({Key? key, this.imagePath, required this.height}) : super(key: key);
+
+  @override
+  State<BannerWidget> createState() => _BannerWidgetState();
+}
+
+class _BannerWidgetState extends State<BannerWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      height: widget.height,
+      color: Colors.blue, // 기본 배경색
+      child: widget.imagePath != null && widget.imagePath!.isNotEmpty
+          ? Image.network(
+              widget.imagePath!,
+              fit: BoxFit.cover,
+            )
+          : const Center(child: Text("Banner Image")),
+    );
+  }
+}

--- a/lib/screen/home/widget/w_chapter_item.dart
+++ b/lib/screen/home/widget/w_chapter_item.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:velocity_x/velocity_x.dart';
+import 'package:word_english/common/constant/app_colors.dart';
+import 'package:word_english/common/widget/widget_constant.dart';
+import 'package:word_english/model/chapter_item_model.dart';
+import 'package:word_english/screen/home/widget/w_linear_progress.dart';
+
+class ChapterItemWidget extends StatefulWidget {
+  final ChapterItem chapterItem;
+
+  const ChapterItemWidget({super.key, required this.chapterItem});
+
+  @override
+  State<ChapterItemWidget> createState() => _ChapterItemWidgetState();
+}
+
+class _ChapterItemWidgetState extends State<ChapterItemWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Card(
+          elevation: 3,
+          color: Theme.of(context).cardColor,
+          child: Stack(
+            children: [
+              SizedBox(
+                width: double.infinity,
+                height: 140,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    'Chapter ${widget.chapterItem.chapter}'
+                        .text
+                        .bold
+                        .size(24)
+                        .make(),
+                    '최근 학습 xx일 전'.text.color(AppColors.grey).make(),
+                  ],
+                ).p(16),
+              ),
+              Positioned.fill(
+                child: Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      const CustomLinearProgress(progress: 0.3),
+                      width10,
+                      '진행률 %'.text.make()
+                    ],
+                  ).p(16),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/screen/home/widget/w_linear_progress.dart
+++ b/lib/screen/home/widget/w_linear_progress.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class CustomLinearProgress extends StatelessWidget {
+  final double progress;
+  const CustomLinearProgress({super.key, required this.progress});
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Container(
+        height: 10, // 진행 표시기의 높이 설정
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(5), // 둥근 모서리 설정
+          color: Colors.grey.shade300, // 배경색 설정
+        ),
+        child: ClipRRect(
+          borderRadius: BorderRadius.circular(5), // 둥근 모서리 설정
+          child: LinearProgressIndicator(
+            value: progress, // 진행률 값
+            valueColor: AlwaysStoppedAnimation<Color>(Colors.blue), // 진행률 색상 설정
+            backgroundColor: Colors.grey.shade300, // 배경색 설정
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screen/s_main.dart
+++ b/lib/screen/s_main.dart
@@ -20,14 +20,30 @@ class _MainScreenState extends State<MainScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: NavBody(
-        index: index,
+      body: Stack(
+        children: [
+          NavBody(
+            index: index,
+          ),
+          Positioned(
+            left: 0,
+            right: 0,
+            bottom: 0,
+            child: Container(
+              color: Colors.grey[300],
+              height: 60, // 광고 배너 높이 설정
+              child: const Center(
+                child: Text("광고 배너"),
+              ),
+            ),
+          ),
+        ],
       ),
       bottomNavigationBar: BottomNavigationBar(
         type: BottomNavigationBarType.shifting,
         selectedItemColor: Colors.black,
-        unselectedItemColor: Colors.white,
-        backgroundColor: Colors.grey,
+        unselectedItemColor: Colors.grey,
+        backgroundColor: Colors.white,
         currentIndex: index,
         onTap: (value) => setState(() => index = value),
         items: const [

--- a/lib/util/local_json.dart
+++ b/lib/util/local_json.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import 'package:flutter/services.dart';
+import 'package:word_english/model/chapter_item_model.dart';
+
+class LocalJson {
+  static Future<T> getObject<T>(String filePath) async {
+    final string = await getJsonString(filePath);
+    final json = jsonDecode(string);
+    return _tryConverting(json);
+  }
+
+  static Future<List<T>> getObjectList<T>(String filePath) async {
+    final string = await getJsonString(filePath);
+    final json = jsonDecode(string);
+    if (json is List) {
+      return json.map<T>((e) => _tryConverting(e)).toList();
+    }
+    return [];
+  }
+
+  static dynamic getJson(String filePath) async {
+    final string = await getJsonString(filePath);
+    return jsonDecode(string);
+  }
+
+  static Future<String> getJsonString(String filePath) async {
+    return await rootBundle.loadString('assets/$filePath');
+  }
+}
+
+T _tryConverting<T>(dynamic json) {
+  switch (T) {
+    case ChapterItem:
+    // case ChapterItem _:
+      return ChapterItem.fromJson(json) as T;
+    default:
+      throw Exception("Please check _tryConverting method");
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
> closed : #6

## 📝작업 내용
> 로컬 json 파싱 유틸 생성
> Spacer, SizedBox 사용한 너비/높이 상수 위젯 생성
> 로컬 json 으로 실제 학습 데이터 파싱
> 홈 화면에 상단 배너 구현
> 홈 화면에 챕터 목록과 정보 카드 레이아웃 구현
> 메인 스크린 공통으로 광고 영역 추가

## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요